### PR TITLE
Cached image iplot

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -97,8 +97,13 @@ def get_credentials():
 
 ### plot stuff ###
 
-def iplot(figure_or_data, **plot_options):
+def iplot(figure_or_data, cached=False, **plot_options):
     """Create a unique url for this plot in Plotly and open in IPython.
+
+    cached (bool) -- Show a static image of the graph while the interactive
+                     version loads. Note: the interactive version will
+                     not display on notebooks if Javascript can't be run,
+                     e.g. notebooks shared with nbviewer.
 
     plot_options keyword agruments:
     filename (string) -- the name that will be associated with this figure


### PR DESCRIPTION
On calling `iplot`, render an image first then replace it with the interactive version once it loads. If offline, the image of the graph will still be viewable. Re-opening notebooks will be fast with the cached images.

Example: http://nbviewer.ipython.org/gist/chriddyp/e567a9d1dd659a6b397b
