### PR TITLE
Fix tests on master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ test:
 
     # test that giving back write permissions works again
     # this also has to pass the test suite that follows
-    - sudo chmod -R 666 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
+    - sudo chmod -R 777 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
 
     # test core things in the general 2.7 version that circle has
     - nosetests -xv plotly/tests/test_core --with-coverage --cover-package=plotly

--- a/circle.yml
+++ b/circle.yml
@@ -34,6 +34,6 @@ test:
 #    - sudo chmod 600 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
 
     # test core things in the general 2.7 version that circle has
-    - nosetests -xv plotly/tests --with-coverage --cover-package=plotly
+    - nosetests -xv plotly/tests/test_core --with-coverage --cover-package=plotly
     - mkdir "${CIRCLE_ARTIFACTS}/2.7" || true
     - coverage html -d "${CIRCLE_ARTIFACTS}/2.7" --title=2.7

--- a/circle.yml
+++ b/circle.yml
@@ -28,10 +28,11 @@ test:
     - bash circle/test.sh
 
     # test that it imports when you don't have write permissions
-    - sudo chmod 444 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
+    - sudo chmod -R 444 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
 
     # test that giving back write permissions works again
-    - sudo chmod 666 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
+    # this also has to pass the test suite that follows
+    - sudo chmod -R 666 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
 
     # test core things in the general 2.7 version that circle has
     - nosetests -xv plotly/tests/test_core --with-coverage --cover-package=plotly

--- a/circle.yml
+++ b/circle.yml
@@ -27,11 +27,11 @@ test:
     # run test suite in all our python versions
     - bash circle/test.sh
 
-#    # test that it imports when you don't have file permissions
-#    - sudo chmod 400 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
-#
-#    # test that setting permissions will work for import (and tests)
-#    - sudo chmod 600 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
+    # test that it imports when you don't have write permissions
+    - sudo chmod 444 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
+
+    # test that giving back write permissions works again
+    - sudo chmod 666 ${PLOTLY_CONFIG_DIR} && python -c "import plotly"
 
     # test core things in the general 2.7 version that circle has
     - nosetests -xv plotly/tests/test_core --with-coverage --cover-package=plotly

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(name='plotly',
                 'plotly/matplotlylib/mplexporter',
                 'plotly/matplotlylib/mplexporter/renderers'],
       package_data={'plotly': ['graph_reference/*.json', 'widgets/*.js']},
-      install_requires=['requests', 'six', 'pytz'],
+      install_requires=['requests[security]', 'six', 'pytz'],
       extras_require={"PY2.6": ['simplejson', 'ordereddict',
                                 'requests[security]']},
       zip_safe=False)


### PR DESCRIPTION
* Removes those `InsecurePlatformWarning` warnings discussed in #214.
* Runs the permissions tests again (removed during test overhaul)