### PR TITLE
Remove validation errors

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -53,7 +53,7 @@ Once you've made your changes (and hopefully written some tests...), make that p
 ##Suggestions
 
 ###Local Python
-Setting up Python versions that *don't* require you to use `sudo` is a good idea. In addition, the core Python on your machine may not be the Python that we've developed in! Here are some nice guides for Mac, Windows, and Linux: 
+Setting up Python versions that *don't* require you to use `sudo` is a good idea. In addition, the core Python on your machine may not be the Python that we've developed in! Here are some nice guides for Mac, Windows, and Linux:
 - http://docs.python-guide.org/en/latest/starting/install/osx/
 - http://docs.python-guide.org/en/latest/starting/install/win/
 - http://docs.python-guide.org/en/latest/starting/install/linux/
@@ -82,7 +82,7 @@ export PYTHONPATH="/path/to/local/repo:$PYTHONPATH"
 
 ##Dependencies
 
-There's a short list of core dependencies you'll need installed in your Python environment to have any sort of fun with Plotly's Python API (see `requirements.txt`). Additionally, you're likely to have even more fun if you install some other requirements (see `optional-requirements.txt`). 
+There's a short list of core dependencies you'll need installed in your Python environment to have any sort of fun with Plotly's Python API (see `requirements.txt`). Additionally, you're likely to have even more fun if you install some other requirements (see `optional-requirements.txt`).
 
 ###Dependencies and Virtualenv
 
@@ -121,18 +121,18 @@ nosetests -w plotly/tests -v
 Either of those will run *every* test we've written for the Python API. You can get more granular by running something like:
 
 ```bash
-nosetests -w plotly/tests/test_plotly
+nosetests -w plotly/tests/test_core/test_plotly
 ```
 
 ... or even more granular by running something like:
 
 ```bash
-nosetests plotly/tests/test_plotly/test_plot.py
+nosetests plotly/tests/test_core/test_plotly/test_plot.py
 ```
 
 ###Writing Tests
 
-You're *strongly* encouraged to write tests that check your added functionality. 
+You're *strongly* encouraged to write tests that check your added functionality.
 
 When you write a new test anywhere under the `tests` directory, if your PR gets accepted, that test will run in a virtual machine to ensure that future changes don't break your contributions!
 

--- a/plotly/tests/test_core/test_graph_objs/test_annotations.py
+++ b/plotly/tests/test_core/test_graph_objs/test_annotations.py
@@ -6,6 +6,7 @@ A module intended for use with Nose.
 
 """
 from __future__ import absolute_import
+import warnings
 
 from nose.tools import raises
 from plotly.graph_objs import *
@@ -34,14 +35,10 @@ def test_dict_instantiation():
     Annotations([{'text': 'annotation text'}])
 
 
-@raises(PlotlyDictKeyError)
 def test_dict_instantiation_key_error():
-    print(Annotations([{'not-a-key': 'anything'}]))
-
-
-@raises(PlotlyDictValueError)
-def test_dict_instantiation_key_error():
-    print(Annotations([{'font': 'not-a-dict'}]))
+    with warnings.catch_warnings(True) as w:
+        print(Annotations([{'not-a-key': 'anything'}]))
+        assert(len(w) > 1)
 
 
 @raises(PlotlyListEntryError)
@@ -73,9 +70,9 @@ def test_validate():
     annotations.validate()
 
 
-@raises(PlotlyDictKeyError)
 def test_validate_error():
     annotations = Annotations()
     annotations.append({'not-a-key': 'anything'})
-    annotations.validate()
-
+    with warnings.catch_warnings(True) as w:
+        annotations.validate()
+        assert len(w) > 1

--- a/plotly/tests/test_core/test_graph_objs/test_data.py
+++ b/plotly/tests/test_core/test_graph_objs/test_data.py
@@ -6,6 +6,7 @@ A module intended for use with Nose.
 
 """
 from __future__ import absolute_import
+import warnings
 
 from nose.tools import raises
 from plotly.graph_objs import *
@@ -38,14 +39,10 @@ def test_dict_instantiation():
     Data([{'type': 'scatter'}])
 
 
-@raises(PlotlyDictKeyError)
 def test_dict_instantiation_key_error():
-    print(Data([{'not-a-key': 'anything'}]))
-
-
-@raises(PlotlyDictValueError)
-def test_dict_instantiation_key_error():
-    print(Data([{'marker': 'not-a-dict'}]))
+    with warnings.catch_warnings(True) as w:
+        print(Data([{'not-a-key': 'anything'}]))
+        assert len(w) > 1
 
 
 @raises(PlotlyDataTypeError)
@@ -82,9 +79,9 @@ def test_validate():
     data.validate()
 
 
-@raises(PlotlyDictKeyError)
 def test_validate_error():
     data = Data()
     data.append({'not-a-key': 'anything'})
-    data.validate()
-
+    with warnings.catch_warnings(True) as w:
+        data.validate()
+        assert len(w) > 1

--- a/plotly/tests/test_core/test_graph_objs/test_error_bars.py
+++ b/plotly/tests/test_core/test_graph_objs/test_error_bars.py
@@ -6,6 +6,7 @@ A module intended for use with Nose.
 
 """
 from __future__ import absolute_import
+import warnings
 
 from nose.tools import raises
 from plotly.graph_objs import *
@@ -46,6 +47,7 @@ def test_instantiate_error_y():
            width=5)
 
 
-@raises(PlotlyDictKeyError)
 def test_key_error():
-    ErrorX(value=0.1, typ='percent', color='red')
+    with warnings.catch_warnings(True) as w:
+        ErrorX(value=0.1, typ='percent', color='red')
+        assert len(w) > 1


### PR DESCRIPTION
hey @etpinard @theengineear @aneda @cldougl - we're adding a ton of new features to the documentation. here's a stop-gap solution until graph_reference gets updated. i'm too embarrassed to tell folks to change their `Scatter` to `dict` and add `validate=False` to their scripts.

Also, I couldn't run tests locally, so i'm just running them on circle for now

```
♡ nosetests plotly/tests/test_core/test_graph_objs/
E
======================================================================
ERROR: Failure: IOError ([Errno 2] No such file or directory: '//anaconda/plotly-data/graph_reference/graph_objs_meta.json')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "//anaconda/lib/python2.7/site-packages/nose/loader.py", line 414, in loadTestsFromName
    addr.filename, addr.module)
  File "//anaconda/lib/python2.7/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "//anaconda/lib/python2.7/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/Users/chris/plotlygithub/python-api/plotly/__init__.py", line 31, in <module>
    from plotly import plotly, graph_objs, grid_objs, tools, utils, session
  File "/Users/chris/plotlygithub/python-api/plotly/plotly/__init__.py", line 10, in <module>
    from . plotly import (
  File "/Users/chris/plotlygithub/python-api/plotly/plotly/plotly.py", line 40, in <module>
    from plotly import tools
  File "/Users/chris/plotlygithub/python-api/plotly/tools.py", line 22, in <module>
    from plotly.graph_objs import graph_objs
  File "/Users/chris/plotlygithub/python-api/plotly/graph_objs/__init__.py", line 12, in <module>
    from . graph_objs import (
  File "/Users/chris/plotlygithub/python-api/plotly/graph_objs/graph_objs.py", line 29, in <module>
    from plotly.graph_objs import graph_objs_tools
  File "/Users/chris/plotlygithub/python-api/plotly/graph_objs/graph_objs_tools.py", line 54, in <module>
    INFO, OBJ_MAP, NAME_TO_KEY, KEY_TO_NAME = _load_graph_ref()
  File "/Users/chris/plotlygithub/python-api/plotly/graph_objs/graph_objs_tools.py", line 47, in _load_graph_ref
    with open(path, 'r') as f:
IOError: [Errno 2] No such file or directory: '//anaconda/plotly-data/graph_reference/graph_objs_meta.json'

----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```