### PR TITLE
Fix failing test and refact to TestCase.

### DIFF
--- a/plotly/tests/test_core/test_file/test_file.py
+++ b/plotly/tests/test_core/test_file/test_file.py
@@ -5,47 +5,47 @@ test_meta:
 A module intended for use with Nose.
 
 """
-
-from nose.tools import raises
-from nose import with_setup
-
 import random
 import string
-import requests
+from unittest import TestCase
 
 import plotly.plotly as py
-import plotly.tools as tls
 from plotly.exceptions import PlotlyRequestError
 
 
-def _random_filename():
-    random_chars = [random.choice(string.ascii_uppercase) for _ in range(5)]
-    unique_filename = 'Valid Folder'+''.join(random_chars)
-    return unique_filename
+class FolderAPITestCase(TestCase):
 
+    def setUp(self):
+        py.sign_in('PythonTest', '9v9f20pext')
 
-def init():
-    py.sign_in('PythonTest', '9v9f20pext')
+    def _random_filename(self):
+        random_chars = [random.choice(string.ascii_uppercase)
+                        for _ in range(5)]
+        unique_filename = 'Valid Folder'+''.join(random_chars)
+        return unique_filename
 
+    def test_create_folder(self):
+        try:
+            py.file_ops.mkdirs(self._random_filename())
+        except PlotlyRequestError as e:
+            self.fail('Expected this *not* to fail! Status: {}'
+                      .format(e.status_code))
 
-@with_setup(init)
-def test_create_folder():
-    py.file_ops.mkdirs(_random_filename())
+    def test_create_nested_folders(self):
+        first_folder = self._random_filename()
+        nested_folder = '{0}/{1}'.format(first_folder, self._random_filename())
+        try:
+            py.file_ops.mkdirs(nested_folder)
+        except PlotlyRequestError as e:
+            self.fail('Expected this *not* to fail! Status: {}'
+                      .format(e.status_code))
 
-
-@with_setup(init)
-def test_create_nested_folders():
-    first_folder = _random_filename()
-    nested_folder = '{0}/{1}'.format(first_folder, _random_filename())
-    py.file_ops.mkdirs(nested_folder)
-
-
-@with_setup(init)
-def test_duplicate_folders():
-    first_folder = _random_filename()
-    py.file_ops.mkdirs(first_folder)
-    try:
+    def test_duplicate_folders(self):
+        first_folder = self._random_filename()
         py.file_ops.mkdirs(first_folder)
-    except PlotlyRequestError as e:
-        if e.status_code != 409:
-            raise e
+        try:
+            py.file_ops.mkdirs(first_folder)
+        except PlotlyRequestError as e:
+            self.assertTrue(400 <= e.status_code < 500)
+        else:
+            self.fail('Expected this to fail!')

--- a/plotly/tests/test_optional/test_utils/test_utils.py
+++ b/plotly/tests/test_optional/test_utils/test_utils.py
@@ -225,7 +225,7 @@ def test_pandas_json_encoding():
     # Test that data wasn't mutated
     assert_series_equal(df['col 1'],
                         pd.Series([1, 2, 3, dt(2014, 1, 5),
-                                   pd.NaT, np.NaN, np.Inf]))
+                                   pd.NaT, np.NaN, np.Inf], name='col 1'))
 
     j2 = json.dumps(df.index, cls=utils.PlotlyJSONEncoder)
     assert(j2 == '[0, 1, 2, 3, 4, 5, 6]')


### PR DESCRIPTION
Attempting to fix the failing test due to a 409 --> 400 in plotly's /folders endpoint.