### PR TITLE
Plotly proxy auth

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1212,7 +1212,7 @@ class _api_v2:
             headers['authorization'] = 'Basic ' + encoded_proxy_auth
             headers['plotly-authorization'] = 'Basic ' + encoded_api_auth
         else:
-            headers['authorization'] = 'Basic ' + encoded_api_auth,
+            headers['authorization'] = 'Basic ' + encoded_api_auth
 
         return headers
 

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1201,18 +1201,14 @@ class _api_v2:
             username, api_key))).decode('utf8')
 
         headers = {
-            'authorization': 'Basic ' + encoded_api_auth,
             'plotly-client-platform': 'python {0}'.format(version.__version__)
         }
 
         if get_config()['plotly_proxy_authorization']:
-
-            # custom enterprise + proxy authentication
             proxy_username = credentials['proxy_username']
-            proxy_passwd = credentials['proxy_passwd']
+            proxy_password = credentials['proxy_password']
             encoded_proxy_auth = base64.b64encode(six.b('{0}:{1}'.format(
-                proxy_username, proxy_passwd))).decode('utf8')
-
+                proxy_username, proxy_password))).decode('utf8')
             headers['authorization'] = 'Basic ' + encoded_proxy_auth
             headers['plotly-authorization'] = 'Basic ' + encoded_api_auth
 

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1211,6 +1211,8 @@ class _api_v2:
                 proxy_username, proxy_password))).decode('utf8')
             headers['authorization'] = 'Basic ' + encoded_proxy_auth
             headers['plotly-authorization'] = 'Basic ' + encoded_api_auth
+        else:
+            headers['authorization'] = 'Basic ' + encoded_api_auth,
 
         return headers
 

--- a/plotly/session.py
+++ b/plotly/session.py
@@ -44,14 +44,17 @@ def sign_in(username, api_key, **kwargs):
 
     If unspecified, credentials and config are searched for in `.plotly` dir.
 
-    :param (str) username: The username you'd use to sign into Plotly
+    :param (str) username: The username you'd use to sign in to Plotly
     :param (str) api_key: The api key associated with above username
     :param (list|optional) stream_ids: Stream tokens for above credentials
+    :param (str|optional) proxy_username: The un associated with with your Proxy
+    :param (str|optional) proxy_password: The pw associated with your Proxy un
 
     :param (str|optional) plotly_domain:
     :param (str|optional) plotly_streaming_domain:
     :param (str|optional) plotly_api_domain:
-    :param (str|optional) plotly_ssl_verification:
+    :param (bool|optional) plotly_ssl_verification:
+    :param (bool|optional) plotly_proxy_authorization:
 
     """
     # TODO: verify these _credentials with plotly

--- a/plotly/tests/test_core/test_tools/test_file_tools.py
+++ b/plotly/tests/test_core/test_tools/test_file_tools.py
@@ -10,17 +10,24 @@ def test_reset_config_file():
 
 def test_set_config_file():
     pd, ps = 'this', 'thing'
-    tls.set_config_file(plotly_domain=pd, plotly_streaming_domain=ps)
+    ssl_verify, proxy_auth = True, True
+    tls.set_config_file(plotly_domain=pd, plotly_streaming_domain=ps,
+                        plotly_ssl_verification=ssl_verify,
+                        plotly_proxy_authorization=proxy_auth)
     config = tls.get_config_file()
     assert config['plotly_domain'] == pd
     assert config['plotly_streaming_domain'] == ps
+    assert config['plotly_ssl_verification'] == ssl_verify
+    assert config['plotly_proxy_authorization'] == proxy_auth
     tls.reset_config_file()  # else every would hate me :)
 
 
 def test_credentials_tools():
     original_creds = tls.get_credentials_file()
-    expected = ['username', 'stream_ids', 'api_key']
+    expected = ['username', 'stream_ids', 'api_key', 'proxy_username',
+                'proxy_password']
     assert all(x in original_creds for x in expected)
+
     # now, if that worked, we can try this!
     tls.reset_credentials_file()
     reset_creds = tls.get_credentials_file()

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -55,7 +55,8 @@ _FILE_CONTENT = {CREDENTIALS_FILE: {'username': '',
                  CONFIG_FILE: {'plotly_domain': 'https://plot.ly',
                                'plotly_streaming_domain': 'stream.plot.ly',
                                'plotly_api_domain': 'https://api.plot.ly',
-                               'plotly_ssl_verification': True}}
+                               'plotly_ssl_verification': True,
+                               'plotly_proxy_authorization': False}}
 
 try:
     os.mkdir(TEST_DIR)
@@ -153,7 +154,8 @@ def reset_credentials_file():
 def set_config_file(plotly_domain=None,
                     plotly_streaming_domain=None,
                     plotly_api_domain=None,
-                    plotly_ssl_verification=None):
+                    plotly_ssl_verification=None,
+                    plotly_proxy_authorization=None):
     """Set the keyword-value pairs in `~/.plotly/.config`.
 
     """
@@ -170,6 +172,8 @@ def set_config_file(plotly_domain=None,
         settings['plotly_api_domain'] = plotly_api_domain
     if isinstance(plotly_ssl_verification, (six.string_types, bool)):
         settings['plotly_ssl_verification'] = plotly_ssl_verification
+    if isinstance(plotly_proxy_authorization, (six.string_types, bool)):
+        settings['plotly_proxy_authorization'] = plotly_proxy_authorization
     utils.save_json_dict(CONFIG_FILE, settings)
     ensure_local_plotly_files()  # make sure what we just put there is OK
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -48,6 +48,9 @@ TEST_FILE = os.path.join(PLOTLY_DIR, ".permission_test")
 # this sets both the DEFAULTS and the TYPES for these items
 _FILE_CONTENT = {CREDENTIALS_FILE: {'username': '',
                                     'api_key': '',
+                                    'proxy_username': '',
+                                    'proxy_passwd': '',
+                                    'api_key': '',
                                     'stream_ids': []},
                  CONFIG_FILE: {'plotly_domain': 'https://plot.ly',
                                'plotly_streaming_domain': 'stream.plot.ly',
@@ -99,7 +102,8 @@ def ensure_local_plotly_files():
 
 ### credentials tools ###
 
-def set_credentials_file(username=None, api_key=None, stream_ids=None):
+def set_credentials_file(username=None, api_key=None, proxy_username=None,
+                         proxy_passwd=None, stream_ids=None):
     """Set the keyword-value pairs in `~/.plotly_credentials`.
 
     """
@@ -112,6 +116,10 @@ def set_credentials_file(username=None, api_key=None, stream_ids=None):
         credentials['username'] = username
     if isinstance(api_key, six.string_types):
         credentials['api_key'] = api_key
+    if isinstance(proxy_username, six.string_types):
+        credentials['proxy_username'] = proxy_username
+    if isinstance(proxy_passwd, six.string_types):
+        credentials['proxy_passwd'] = proxy_passwd
     if isinstance(stream_ids, (list, tuple)):
         credentials['stream_ids'] = stream_ids
     utils.save_json_dict(CREDENTIALS_FILE, credentials)

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -168,7 +168,7 @@ def set_config_file(plotly_domain=None,
     """Set the keyword-value pairs in `~/.plotly/.config`.
 
     :param (str) plotly_domain: ex - https://plot.ly
-    :param (str) plotly_streaming_domain: ex - https://stream.plot.ly
+    :param (str) plotly_streaming_domain: ex - stream.plot.ly
     :param (str) plotly_api_domain: ex - https://api.plot.ly
     :param (bool) plotly_ssl_verification: True = verify, False = don't verify
     :param (bool) plotly_proxy_authorization: True = use plotly proxy auth creds

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -107,6 +107,12 @@ def set_credentials_file(username=None, api_key=None, proxy_username=None,
                          proxy_passwd=None, stream_ids=None):
     """Set the keyword-value pairs in `~/.plotly_credentials`.
 
+    :param (str) username: The username you'd use to sign in to Plotly
+    :param (str) api_key: The api key associated with above username
+    :param (list) stream_ids: Stream tokens for above credentials
+    :param (str) proxy_username: The un associated with with your Proxy
+    :param (str) proxy_password: The pw associated with your Proxy un
+
     """
     if not _file_permissions:
         raise exceptions.PlotlyError("You don't have proper file permissions "
@@ -157,6 +163,12 @@ def set_config_file(plotly_domain=None,
                     plotly_ssl_verification=None,
                     plotly_proxy_authorization=None):
     """Set the keyword-value pairs in `~/.plotly/.config`.
+
+    :param (str) plotly_domain: ex - https://plot.ly
+    :param (str) plotly_streaming_domain: ex - https://stream.plot.ly
+    :param (str) plotly_api_domain: ex - https://api.plot.ly
+    :param (bool) plotly_ssl_verification: True = verify, False = don't verify
+    :param (bool) plotly_proxy_authorization: True = use plotly proxy auth creds
 
     """
     if not _file_permissions:

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -49,7 +49,7 @@ TEST_FILE = os.path.join(PLOTLY_DIR, ".permission_test")
 _FILE_CONTENT = {CREDENTIALS_FILE: {'username': '',
                                     'api_key': '',
                                     'proxy_username': '',
-                                    'proxy_passwd': '',
+                                    'proxy_password': '',
                                     'api_key': '',
                                     'stream_ids': []},
                  CONFIG_FILE: {'plotly_domain': 'https://plot.ly',
@@ -103,8 +103,11 @@ def ensure_local_plotly_files():
 
 ### credentials tools ###
 
-def set_credentials_file(username=None, api_key=None, proxy_username=None,
-                         proxy_passwd=None, stream_ids=None):
+def set_credentials_file(username=None,
+                         api_key=None,
+                         stream_ids=None,
+                         proxy_username=None,
+                         proxy_password=None):
     """Set the keyword-value pairs in `~/.plotly_credentials`.
 
     :param (str) username: The username you'd use to sign in to Plotly
@@ -125,8 +128,8 @@ def set_credentials_file(username=None, api_key=None, proxy_username=None,
         credentials['api_key'] = api_key
     if isinstance(proxy_username, six.string_types):
         credentials['proxy_username'] = proxy_username
-    if isinstance(proxy_passwd, six.string_types):
-        credentials['proxy_passwd'] = proxy_passwd
+    if isinstance(proxy_password, six.string_types):
+        credentials['proxy_password'] = proxy_password
     if isinstance(stream_ids, (list, tuple)):
         credentials['stream_ids'] = stream_ids
     utils.save_json_dict(CREDENTIALS_FILE, credentials)


### PR DESCRIPTION
@chriddyp @theengineear. This allows enterprise users working behind a proxy to specify `Plotly-Authorization` header as a `basic auth` header for our `API v2`. This frees up the `Authorization` header for the initial proxy layer. For now, it is up to the server admin to handle converting the `Plotly-Authorization` header to the expected `Authorization` header for basic auth once authorized over the proxy.  In the future, we could simply accept both `Plotly-Authorization` and `Authorization` headers in our back end so the server admin won't need to do anything. I added a flag in the config file for `plotly_proxy_authorization`. 

todo: 
- [x] extend the tests