### PR TITLE
Config file safe tests

### DIFF
--- a/plotly/tests/test_core/test_tools/test_file_tools.py
+++ b/plotly/tests/test_core/test_tools/test_file_tools.py
@@ -1,10 +1,9 @@
-from unittest import TestCase
-
 from plotly import tools
 from plotly import session
+from plotly.tests.utils import PlotlyTestCase
 
 
-class FileToolsTest(TestCase):
+class FileToolsTest(PlotlyTestCase):
 
     def test_set_config_file_all_entries(self):
 

--- a/plotly/tests/utils.py
+++ b/plotly/tests/utils.py
@@ -10,31 +10,31 @@ class PlotlyTestCase(TestCase):
     # parent test case to assist with clean up of local credentials/config
 
     def __init__(self, **kwargs):
-        self._credentials = None
-        self._config = None
+        self._file_credentials = None
+        self._file_config = None
         super(PlotlyTestCase, self).__init__(**kwargs)
 
     def setUp(self):
-        self.stash_credentials_and_config()
+        self.stash_file_credentials_and_config()
 
     def tearDown(self):
-        self.restore_credentials_and_config()
+        self.restore_file_credentials_and_config()
 
-    def stash_credentials_and_config(self):
+    def stash_file_credentials_and_config(self):
         if _file_permissions:
             with open(CREDENTIALS_FILE, 'r') as f:
-                self._credentials = json.load(f)
+                self._file_credentials = json.load(f)
             with open(CONFIG_FILE, 'r') as f:
-                self._config = json.load(f)
+                self._file_config = json.load(f)
 
-    def restore_credentials_and_config(self):
+    def restore_file_credentials_and_config(self):
         if _file_permissions:
-            if self._credentials is not None:
+            if self._file_credentials is not None:
                 with open(CREDENTIALS_FILE, 'w') as f:
-                    json.dump(self._credentials, f)
-            if self._config is not None:
+                    json.dump(self._file_credentials, f)
+            if self._file_config is not None:
                 with open(CONFIG_FILE, 'w') as f:
-                    json.load(self._config, f)
+                    json.load(self._file_config, f)
 
 
 def compare_dict(dict1, dict2, equivalent=True, msg='', tol=10e-8):

--- a/plotly/tests/utils.py
+++ b/plotly/tests/utils.py
@@ -46,6 +46,7 @@ class PlotlyTestCase(TestCase):
         session._session.clear()  # clear and update to preserve references.
         session._session.update(self._session)
 
+
 def compare_dict(dict1, dict2, equivalent=True, msg='', tol=10e-8):
     for key in dict1:
         if key not in dict2:

--- a/plotly/tests/utils.py
+++ b/plotly/tests/utils.py
@@ -1,4 +1,40 @@
+import json
 from numbers import Number as Num
+from unittest import TestCase
+
+from plotly.tools import CREDENTIALS_FILE, CONFIG_FILE, _file_permissions
+
+
+class PlotlyTestCase(TestCase):
+
+    # parent test case to assist with clean up of local credentials/config
+
+    def __init__(self, **kwargs):
+        self._credentials = None
+        self._config = None
+        super(PlotlyTestCase, self).__init__(**kwargs)
+
+    def setUp(self):
+        self.stash_credentials_and_config()
+
+    def tearDown(self):
+        self.restore_credentials_and_config()
+
+    def stash_credentials_and_config(self):
+        if _file_permissions:
+            with open(CREDENTIALS_FILE, 'r') as f:
+                self._credentials = json.load(f)
+            with open(CONFIG_FILE, 'r') as f:
+                self._config = json.load(f)
+
+    def restore_credentials_and_config(self):
+        if _file_permissions:
+            if self._credentials is not None:
+                with open(CREDENTIALS_FILE, 'w') as f:
+                    json.dump(self._credentials, f)
+            if self._config is not None:
+                with open(CONFIG_FILE, 'w') as f:
+                    json.load(self._config, f)
 
 
 def compare_dict(dict1, dict2, equivalent=True, msg='', tol=10e-8):

--- a/plotly/tests/utils.py
+++ b/plotly/tests/utils.py
@@ -1,7 +1,9 @@
+import copy
 import json
 from numbers import Number as Num
 from unittest import TestCase
 
+from plotly import session
 from plotly.tools import CREDENTIALS_FILE, CONFIG_FILE, _file_permissions
 
 
@@ -12,6 +14,7 @@ class PlotlyTestCase(TestCase):
     def __init__(self, **kwargs):
         self._file_credentials = None
         self._file_config = None
+        self._session = None
         super(PlotlyTestCase, self).__init__(**kwargs)
 
     def setUp(self):
@@ -36,6 +39,12 @@ class PlotlyTestCase(TestCase):
                 with open(CONFIG_FILE, 'w') as f:
                     json.load(self._file_config, f)
 
+    def stash_session(self):
+        self._session = copy.deepcopy(session._session)
+
+    def restore_session(self):
+        session._session.clear()  # clear and update to preserve references.
+        session._session.update(self._session)
 
 def compare_dict(dict1, dict2, equivalent=True, msg='', tol=10e-8):
     for key in dict1:


### PR DESCRIPTION
Add some protective isolation of session and file config/credentials between unit tests. This only works when you inherit from the new `TestCase` (`PlotlyTestCase`)