### PR TITLE
decode bytes for python 3.3

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1391,7 +1391,10 @@ def add_share_key_to_url(plot_url):
 
     _api_v2.response_handler(new_response)
 
-    new_response_data = json.loads(new_response.content)
+    # decode bytes for python 3.3: https://bugs.python.org/issue10976
+    str_content = new_response.content.decode('utf-8')
+
+    new_response_data = json.loads(str_content)
     plot_url += '?share_key=' + new_response_data['share_key']
 
     return plot_url


### PR DESCRIPTION
hey @aneda - saw your comment in slack, thought I'd take a look. here's a fix to your tests, and here's how I figured it out:

1 - Installed python3.3 (http://www.python.org/ftp/python/3.3.5/python-3.3.5-macosx10.6.dmg)
2 - Made a 3.3 virtual environment:
```
cd ~/Repos
mkdir venvpy33
cd venvpy33/
virtualenv -p /usr/local/bin/python3.3 . # /usr/local/bin/python3.3 found by calling $ which python3.3
```

added an alias to my `.bash_profile`:
`alias v.33='source ~/Repos/venvpy33/bin/activate'`

3 - Ran the tests with `--pdb`

```
v.33
pip install nose
nosetests plotly/tests/test_core/test_plotly/test_plot.py --pdb
```

4 - the traceback happens at the `json.loads` line:
```
new_response_data = json.loads(new_response.content)
```

```
Traceback (most recent call last):
  File "/Users/chriddyp/Repos/python-api/plotly/tests/test_core/test_plotly/test_plot.py", line 223, in test_plot_url_response_given_sharing_key
    py._send_to_plotly(fig, **kwargs)['url'])
  File "/Users/chriddyp/Repos/python-api/plotly/plotly/plotly.py", line 1440, in _send_to_plotly
    r['url'] = add_share_key_to_url(r['url'])
  File "/Users/chriddyp/Repos/python-api/plotly/plotly/plotly.py", line 1394, in add_share_key_to_url
    new_response_data = json.loads(new_response.content)
  File "/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/json/__init__.py", line 316, in loads
    return _default_decoder.decode(s)
  File "/Library/Frameworks/Python.framework/Versions/3.3/lib/python3.3/json/decoder.py", line 351, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
nose.proxy.TypeError: can't use a string pattern on a bytes-like object
```

5 - googling "python3.3 json.loads can't use a string pattern on a bytes-like object" led me here: http://stackoverflow.com/questions/21436163/typeerror-cant-use-a-string-pattern-on-a-bytes-like-object, and here: https://bugs.python.org/issue10976, which gave the fix.

and finally here is a really good, must-read reference on unicode: http://www.joelonsoftware.com/articles/Unicode.html